### PR TITLE
Make crate documentation example compile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,26 @@
 
 //! Continuously read,write to disk, using random offsets and lengths.
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! # extern crate failure;
+//! # extern crate tempdir;
+//! # use failure::Error;
+//! # fn run_main() -> Result<(), Error> {
+//! extern crate tempdir;
 //! extern crate random_access_disk;
 //!
 //! use std::path::PathBuf;
+//! use tempdir::TempDir;
 //!
 //! let dir = TempDir::new("random-access-disk").unwrap();
-//! let mut file = rad::Sync::new(PathBuf::from("./file.log"));
+//! let mut file = random_access_disk::Sync::new(PathBuf::from("./file.log"));
 //!
 //! file.write(0, b"hello")?;
 //! file.write(5, b" world")?;
 //! let text = file.read(0, 11)?;
+//! # Ok(())
+//! # }
+//! # fn main() {}
 //! ```
 
 // #[macro_use]


### PR DESCRIPTION
**Choose one:** 🐛 bug fix (& 🔦 documentation change)

This makes the main example of the crate actually compile and therefore be tested when `cargo test` is run.
Stuff after a `#` is hidden in the rendered documentation, so there's no change in how the user sees the documentation.
(Meanwhile it also discovered a bug in the example: `rad → random_access_disk`)

## Checklist
- [x] tests pass
- [ ] tests and/or benchmarks are included ← does not apply
- [ ] documentation is changed or added ← does not apply

## Context
-

## Semver Changes
Patch.
