### PR TITLE
quickcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,9 @@ rust:
   - nightly
 
 before_script: |
-  rustup component add rustfmt-preview &&
-  cargo install clippy -f
+  rustup component add rustfmt-preview
 script: |
   cargo fmt -- --write-mode=diff &&
-  cargo clippy -- -D clippy &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ mkdirp = "0.1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"
+quickcheck = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ random-access-storage = "0.3.0"
 mkdirp = "0.1.0"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+clippy = "0.0"
 quickcheck = "0.6.2"
+tempdir = "0.3.7"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ Continuously read,write to disk, using random offsets and lengths. Adapted from
 - [Documentation][8]
 - [Crate][2]
 
+## Usage
+```rust
+extern crate failure;
+extern crate tempdir;
+use failure::Error;
+extern crate tempdir;
+extern crate random_access_disk;
+
+use std::path::PathBuf;
+use tempdir::TempDir;
+
+let dir = TempDir::new("random-access-disk").unwrap();
+let mut file = random_access_disk::Sync::new(PathBuf::from("./file.log"));
+
+file.write(0, b"hello").unwrap();
+file.write(5, b" world").unwrap();
+let _text = file.read(0, 11).unwrap();
+```
+
 ## Installation
 ```sh
 $ cargo add random-access-disk

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ Continuously read,write to disk, using random offsets and lengths. Adapted from
 
 ## Usage
 ```rust
-extern crate failure;
-extern crate tempdir;
-use failure::Error;
 extern crate tempdir;
 extern crate random_access_disk;
 
@@ -20,7 +17,7 @@ use std::path::PathBuf;
 use tempdir::TempDir;
 
 let dir = TempDir::new("random-access-disk").unwrap();
-let mut file = random_access_disk::Sync::new(PathBuf::from("./file.log"));
+let mut file = random_access_disk::Sync::new(dir.path().join("README.db"));
 
 file.write(0, b"hello").unwrap();
 file.write(5, b" world").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,9 @@
-// #![deny(warnings, missing_docs)]
-// #![cfg_attr(test, feature(plugin))]
-// #![cfg_attr(test, plugin(clippy))]
-
-//! Continuously read,write to disk, using random offsets and lengths.
-//!
-//! ```rust,no_run
-//! # extern crate failure;
-//! # extern crate tempdir;
-//! # use failure::Error;
-//! # fn run_main() -> Result<(), Error> {
-//! extern crate tempdir;
-//! extern crate random_access_disk;
-//!
-//! use std::path::PathBuf;
-//! use tempdir::TempDir;
-//!
-//! let dir = TempDir::new("random-access-disk").unwrap();
-//! let mut file = random_access_disk::Sync::new(PathBuf::from("./file.log"));
-//!
-//! file.write(0, b"hello")?;
-//! file.write(5, b" world")?;
-//! let text = file.read(0, 11)?;
-//! # Ok(())
-//! # }
-//! # fn main() {}
-//! ```
+#![deny(missing_docs)]
+#![cfg_attr(test, deny(warnings))]
+#![feature(external_doc)]
+#![doc(include = "../README.md")]
+#![cfg_attr(test, feature(plugin))]
+#![cfg_attr(test, plugin(clippy))]
 
 #[macro_use]
 extern crate failure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! # fn main() {}
 //! ```
 
-// #[macro_use]
+#[macro_use]
 extern crate failure;
 
 /// Synchronous implementation.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -13,9 +13,10 @@ pub struct Sync {}
 
 impl Sync {
   /// Create a new instance.
+  #[cfg_attr(test, allow(new_ret_no_self))]
   pub fn new(filename: path::PathBuf) -> random_access::Sync<SyncMethods> {
     random_access::Sync::new(SyncMethods {
-      filename: filename,
+      filename,
       file: None,
       length: 0,
     })
@@ -26,14 +27,14 @@ impl Sync {
 /// These should generally be kept private, but exposed to prevent leaking
 /// internals.
 pub struct SyncMethods {
-  pub filename: path::PathBuf,
-  pub file: Option<fs::File>,
+  filename: path::PathBuf,
+  file: Option<fs::File>,
   length: u64,
 }
 
 impl random_access::SyncMethods for SyncMethods {
   fn open(&mut self) -> Result<(), Error> {
-    if let &Some(dirname) = &self.filename.parent() {
+    if let Some(dirname) = self.filename.parent() {
       mkdirp::mkdirp(&dirname)?;
     }
 
@@ -51,7 +52,7 @@ impl random_access::SyncMethods for SyncMethods {
   fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), Error> {
     let mut file = self.file.as_ref().expect("self.file was None.");
     file.seek(SeekFrom::Start(offset as u64))?;
-    file.write(&data)?;
+    file.write_all(&data)?;
 
     // We've changed the length of our file.
     let new_len = (offset + data.len()) as u64;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -63,6 +63,14 @@ impl random_access::SyncMethods for SyncMethods {
     Ok(())
   }
 
+  // NOTE(yw): disabling clippy here because we files on disk might be sparse,
+  // and sometimes you might want to read a bit of memory to check if it's
+  // formatted or not. Returning zero'd out memory seems like an OK thing to do.
+  // We should probably come back to this at a future point, and determine
+  // whether it's okay to return a fully zero'd out slice. It's a bit weird,
+  // because we're replacing empty data with actual zeroes - which does not
+  // reflect the state of the world.
+  #[cfg_attr(test, allow(unused_io_amount))]
   fn read(&mut self, offset: usize, length: usize) -> Result<Vec<u8>, Error> {
     ensure!(
       (offset + length) as u64 <= self.length,
@@ -72,7 +80,6 @@ impl random_access::SyncMethods for SyncMethods {
     let mut buffer = vec![0; length];
     file.seek(SeekFrom::Start(offset as u64))?;
     file.read(&mut buffer[..])?;
-    println!("{:?}", offset);
     Ok(buffer)
   }
 

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,38 +1,39 @@
-mod sync {
-  extern crate random_access_disk as rad;
-  extern crate tempdir;
+extern crate random_access_disk as rad;
+extern crate tempdir;
 
-  use self::tempdir::TempDir;
+use self::tempdir::TempDir;
 
-  #[test]
-  fn can_call_new() {
-    let dir = TempDir::new("random-access-disk").unwrap();
-    let _file = rad::Sync::new(dir.path().join("1.db"));
-  }
+#[test]
+fn can_call_new() {
+  let dir = TempDir::new("random-access-disk").unwrap();
+  let _file = rad::Sync::new(dir.path().join("1.db"));
+}
 
-  #[test]
-  fn can_open_buffer() {
-    let dir = TempDir::new("random-access-disk").unwrap();
-    let mut file = rad::Sync::new(dir.path().join("2.db"));
-    file.write(0, b"hello").unwrap();
-    assert!(file.opened);
-  }
+#[test]
+fn can_open_buffer() {
+  let dir = TempDir::new("random-access-disk").unwrap();
+  let mut file = rad::Sync::new(dir.path().join("2.db"));
+  file.write(0, b"hello").unwrap();
+  assert!(file.opened);
+}
 
-  #[test]
-  fn can_write() {
-    let dir = TempDir::new("random-access-disk").unwrap();
-    let mut file = rad::Sync::new(dir.path().join("3.db"));
-    file.write(0, b"hello").unwrap();
-    file.write(5, b" world").unwrap();
-  }
+#[test]
+fn can_write() {
+  let dir = TempDir::new("random-access-disk").unwrap();
+  let mut file = rad::Sync::new(dir.path().join("3.db"));
+  file.write(0, b"hello").unwrap();
+  file.write(5, b" world").unwrap();
+}
 
-  #[test]
-  fn can_read() {
-    let dir = TempDir::new("random-access-disk").unwrap();
-    let mut file = rad::Sync::new(dir.path().join("4.db"));
-    file.write(0, b"hello").unwrap();
-    file.write(5, b" world").unwrap();
-    let text = file.read(0, 11).unwrap();
-    assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello world");
-  }
+#[test]
+fn can_read() {
+  let dir = TempDir::new("random-access-disk").unwrap();
+  let mut file = rad::Sync::new(dir.path().join("4.db"));
+  file.write(0, b"hello").unwrap();
+  file.write(5, b" world").unwrap();
+  let text = file.read(0, 11).unwrap();
+  assert_eq!(
+    String::from_utf8(text.to_vec()).unwrap(),
+    "hello world"
+  );
 }

--- a/tests/sync_model.rs
+++ b/tests/sync_model.rs
@@ -1,0 +1,63 @@
+#[macro_use]
+extern crate quickcheck;
+extern crate random_access_disk as rad;
+extern crate tempdir;
+
+use self::tempdir::TempDir;
+use self::Op::*;
+use quickcheck::{Arbitrary, Gen};
+use std::u8;
+
+const MAX_FILE_SIZE: usize = 5 * 10; // 5mb
+
+#[derive(Clone, Debug)]
+enum Op {
+  Read { offset: usize, length: usize },
+  Write { offset: usize, data: Vec<u8> },
+}
+
+impl Arbitrary for Op {
+  fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    let offset: usize = g.gen_range(0, MAX_FILE_SIZE);
+    let length: usize = g.gen_range(0, MAX_FILE_SIZE / 3);
+
+    if g.gen::<bool>() {
+      Read { offset, length }
+    } else {
+      let mut data = Vec::with_capacity(length);
+      for _ in 0..length {
+        data.push(u8::arbitrary(g));
+      }
+      Write { offset, data }
+    }
+  }
+}
+
+quickcheck! {
+  fn implementation_matches_model(ops: Vec<Op>) -> bool {
+    let dir = TempDir::new("random-access-disk").unwrap();
+    let mut implementation = rad::Sync::new(dir.path().join("1.db"));
+    let mut model = vec![];
+
+    for op in ops {
+      match op {
+        Read { offset, length } => {
+          let end = offset + length;
+          assert_eq!(
+            &*implementation.read(offset, length).expect("Reads should be successful."),
+            &model[offset..end]
+          );
+        },
+        Write { offset, ref data } => {
+          let end = offset + data.len();
+          if model.len() < end {
+            model.resize(end, 0);
+          }
+          implementation.write(offset, &*data).expect("Writes should be successful.");
+          model[offset..end].copy_from_slice(data);
+        },
+      }
+    }
+    true
+  }
+}

--- a/tests/sync_model.rs
+++ b/tests/sync_model.rs
@@ -43,10 +43,14 @@ quickcheck! {
       match op {
         Read { offset, length } => {
           let end = offset + length;
-          assert_eq!(
-            &*implementation.read(offset, length).expect("Reads should be successful."),
-            &model[offset..end]
-          );
+          if model.len() >= end {
+            assert_eq!(
+              &*implementation.read(offset, length).expect("Reads should be successful."),
+              &model[offset..end]
+            );
+          } else {
+            assert!(implementation.read(offset, length).is_err());
+          }
         },
         Write { offset, ref data } => {
           let end = offset + data.len();

--- a/tests/sync_regression.rs
+++ b/tests/sync_regression.rs
@@ -1,0 +1,14 @@
+extern crate random_access_disk as rad;
+extern crate tempdir;
+
+use self::tempdir::TempDir;
+
+#[test]
+// postmortem: read_exact wasn't behaving like we hoped, so we had to switch
+// back to `.read()` and disable clippy for that rule specifically.
+fn regress_1() {
+  let dir = TempDir::new("random-access-disk").unwrap();
+  let mut file = rad::Sync::new(dir.path().join("regression-1.db"));
+  file.write(27, b"").unwrap();
+  file.read(13, 5).unwrap();
+}


### PR DESCRIPTION
As with https://github.com/datrs/random-access-memory/pull/1, we're introducing quickcheck to automate testing. Wip for now.

Probably should also think about how we handle reading out of bounds, because behavior is currently different between the implementations.

## Changes
- added quickcheck
- we now reject reads if they read beyond where a write has occurred. This is now consistent with our memory backend too!
- internally we now keep track of the file length.