### PR TITLE
fix regression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ random-access-storage = "0.3.0"
 mkdirp = "0.1.0"
 
 [dev-dependencies]
-clippy = "0.0"
+# clippy = "0.0"
 quickcheck = "0.6.2"
 tempdir = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 #![cfg_attr(test, deny(warnings))]
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
-#![cfg_attr(test, feature(plugin))]
-#![cfg_attr(test, plugin(clippy))]
+// #![cfg_attr(test, feature(plugin))]
+// #![cfg_attr(test, plugin(clippy))]
 
 #[macro_use]
 extern crate failure;

--- a/tests/sync_regression.rs
+++ b/tests/sync_regression.rs
@@ -2,6 +2,7 @@ extern crate random_access_disk as rad;
 extern crate tempdir;
 
 use self::tempdir::TempDir;
+use std::env;
 
 #[test]
 // postmortem: read_exact wasn't behaving like we hoped, so we had to switch
@@ -11,4 +12,16 @@ fn regress_1() {
   let mut file = rad::Sync::new(dir.path().join("regression-1.db"));
   file.write(27, b"").unwrap();
   file.read(13, 5).unwrap();
+}
+
+#[test]
+// postmortem: accessing the same file twice would fail, so we had to switch to
+// from `.create_new()` to `.create()`.
+//
+// NOTE: test needs to be run twice in a row to trigger regression. I'm sorry.
+fn regress_2() {
+  let mut dir = env::temp_dir();
+  dir.push("regression-2.db");
+  let mut file = rad::Sync::new(dir);
+  file.write(27, b"").unwrap();
 }


### PR DESCRIPTION
Closes #7 & #3. Fixes double use failure + added a drop trait + call `fsync` after each write. Thanks!