### PR TITLE
replace tempdir crate (deprecated) with tempfile crate, using tempfile::Builder to create a tempdir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ mkdirp = "0.1.0"
 
 [dev-dependencies]
 quickcheck = "0.6.2"
-tempdir = "0.3.7"
+tempfile = "3.0.3"

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate quickcheck;
 extern crate random_access_disk as rad;
-extern crate tempdir;
+extern crate tempfile;
 
-use self::tempdir::TempDir;
+use tempfile::Builder;
 use self::Op::*;
 use quickcheck::{Arbitrary, Gen};
 use std::u8;
@@ -35,7 +35,7 @@ impl Arbitrary for Op {
 
 quickcheck! {
   fn implementation_matches_model(ops: Vec<Op>) -> bool {
-    let dir = TempDir::new("random-access-disk").unwrap();
+    let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
 
     let mut implementation = rad::RandomAccessDisk::new(dir.path().join("1.db"));
     let mut model = vec![];

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -3,10 +3,10 @@ extern crate quickcheck;
 extern crate random_access_disk as rad;
 extern crate tempfile;
 
-use tempfile::Builder;
 use self::Op::*;
 use quickcheck::{Arbitrary, Gen};
 use std::u8;
+use tempfile::Builder;
 
 const MAX_FILE_SIZE: usize = 5 * 10; // 5mb
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,14 +1,14 @@
 extern crate random_access_disk as rad;
-extern crate tempdir;
+extern crate tempfile;
 
-use self::tempdir::TempDir;
+use tempfile::Builder;
 use std::env;
 
 #[test]
 // postmortem: read_exact wasn't behaving like we hoped, so we had to switch
 // back to `.read()` and disable clippy for that rule specifically.
 fn regress_1() {
-  let dir = TempDir::new("random-access-disk").unwrap();
+  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("regression-1.db"));
   file.write(27, b"").unwrap();
   file.read(13, 5).unwrap();

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,14 +1,17 @@
 extern crate random_access_disk as rad;
 extern crate tempfile;
 
-use tempfile::Builder;
 use std::env;
+use tempfile::Builder;
 
 #[test]
 // postmortem: read_exact wasn't behaving like we hoped, so we had to switch
 // back to `.read()` and disable clippy for that rule specifically.
 fn regress_1() {
-  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("regression-1.db"));
   file.write(27, b"").unwrap();
   file.read(13, 5).unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,13 +5,19 @@ use tempfile::Builder;
 
 #[test]
 fn can_call_new() {
-  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
   let _file = rad::RandomAccessDisk::new(dir.path().join("1.db"));
 }
 
 #[test]
 fn can_open_buffer() {
-  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("2.db"));
   file.write(0, b"hello").unwrap();
   assert!(file.opened);
@@ -19,7 +25,10 @@ fn can_open_buffer() {
 
 #[test]
 fn can_write() {
-  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("3.db"));
   file.write(0, b"hello").unwrap();
   file.write(5, b" world").unwrap();
@@ -27,7 +36,10 @@ fn can_write() {
 
 #[test]
 fn can_read() {
-  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("4.db"));
   file.write(0, b"hello").unwrap();
   file.write(5, b" world").unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,17 +1,17 @@
 extern crate random_access_disk as rad;
-extern crate tempdir;
+extern crate tempfile;
 
-use self::tempdir::TempDir;
+use tempfile::Builder;
 
 #[test]
 fn can_call_new() {
-  let dir = TempDir::new("random-access-disk").unwrap();
+  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
   let _file = rad::RandomAccessDisk::new(dir.path().join("1.db"));
 }
 
 #[test]
 fn can_open_buffer() {
-  let dir = TempDir::new("random-access-disk").unwrap();
+  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("2.db"));
   file.write(0, b"hello").unwrap();
   assert!(file.opened);
@@ -19,7 +19,7 @@ fn can_open_buffer() {
 
 #[test]
 fn can_write() {
-  let dir = TempDir::new("random-access-disk").unwrap();
+  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("3.db"));
   file.write(0, b"hello").unwrap();
   file.write(5, b" world").unwrap();
@@ -27,7 +27,7 @@ fn can_write() {
 
 #[test]
 fn can_read() {
-  let dir = TempDir::new("random-access-disk").unwrap();
+  let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
   let mut file = rad::RandomAccessDisk::new(dir.path().join("4.db"));
   file.write(0, b"hello").unwrap();
   file.write(5, b" world").unwrap();


### PR DESCRIPTION
 this is a 🙋 feature

## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
I noticed the tests were using the `tempdir` crate which had been deprecated recently: [rust-lang-deprecated/tempdir#45](https://github.com/rust-lang-deprecated/tempdir/issues/45). So this is really just a small clean up to replace `tempdir` with it's new home, the [tempfile crate](https://github.com/Stebalien/tempfile).

The api for `tempdir` has been merged into the `tempfile`.  I'm using the [Builder struct](https://docs.rs/tempfile/3.0.3/tempfile/struct.Builder.html#examples) to create the tempdir with a prefix of `"random-access-disk"`.

I hope this PR isn't too obtrusive, I know it doesn't add much but I'm hoping it helps a little in the grand scheme 😄 

## Semver Changes
patch

p.s., thank you for making this crate!  It's been wonderful seeing Dat be made in rust, and it's inspired me to try to learn rust as well!