### PR TITLE
Random access always open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
 before_script: |
   rustup component add rustfmt-preview
 script: |
+  cargo check --all-targets --verbose &&
   cargo fmt -- --check &&
   cargo build --verbose &&
   cargo test  --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1.1"
-random-access-storage = "0.5.0"
+random-access-storage = "0.6.0"
 mkdirp = "0.1.0"
 
 [dev-dependencies]

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -2,9 +2,11 @@
 
 mod sync {
   extern crate random_access_disk as rad;
+  extern crate random_access_storage;
   extern crate tempfile;
   extern crate test;
 
+  use self::random_access_storage::RandomAccess;
   use self::test::Bencher;
 
   #[bench]
@@ -13,7 +15,8 @@ mod sync {
       .prefix("random-access-disk")
       .tempdir()
       .unwrap();
-    let mut file = rad::RandomAccessDisk::new(dir.path().join("1.db"));
+    let mut file =
+      rad::RandomAccessDisk::open(dir.path().join("1.db")).unwrap();
     b.iter(|| {
       file.write(0, b"hello").unwrap();
       file.write(5, b" world").unwrap();
@@ -26,7 +29,8 @@ mod sync {
       .prefix("random-access-disk")
       .tempdir()
       .unwrap();
-    let mut file = rad::RandomAccessDisk::new(dir.path().join("2.db"));
+    let mut file =
+      rad::RandomAccessDisk::open(dir.path().join("2.db")).unwrap();
     file.write(0, b"hello").unwrap();
     file.write(5, b" world").unwrap();
     b.iter(|| {
@@ -40,7 +44,8 @@ mod sync {
       .prefix("random-access-disk")
       .tempdir()
       .unwrap();
-    let mut file = rad::RandomAccessDisk::new(dir.path().join("3.db"));
+    let mut file =
+      rad::RandomAccessDisk::open(dir.path().join("3.db")).unwrap();
     b.iter(|| {
       file.write(0, b"hello").unwrap();
       file.write(5, b" world").unwrap();

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -2,16 +2,18 @@
 
 mod sync {
   extern crate random_access_disk as rad;
-  extern crate tempdir;
+  extern crate tempfile;
   extern crate test;
 
-  use self::tempdir::TempDir;
   use self::test::Bencher;
 
   #[bench]
   fn write_hello_world(b: &mut Bencher) {
-    let dir = TempDir::new("random-access-disk").unwrap();
-    let mut file = rad::Sync::new(dir.path().join("1.db"));
+    let dir = tempfile::Builder::new()
+      .prefix("random-access-disk")
+      .tempdir()
+      .unwrap();
+    let mut file = rad::RandomAccessDisk::new(dir.path().join("1.db"));
     b.iter(|| {
       file.write(0, b"hello").unwrap();
       file.write(5, b" world").unwrap();
@@ -20,8 +22,11 @@ mod sync {
 
   #[bench]
   fn read_hello_world(b: &mut Bencher) {
-    let dir = TempDir::new("random-access-disk").unwrap();
-    let mut file = rad::Sync::new(dir.path().join("2.db"));
+    let dir = tempfile::Builder::new()
+      .prefix("random-access-disk")
+      .tempdir()
+      .unwrap();
+    let mut file = rad::RandomAccessDisk::new(dir.path().join("2.db"));
     file.write(0, b"hello").unwrap();
     file.write(5, b" world").unwrap();
     b.iter(|| {
@@ -31,8 +36,11 @@ mod sync {
 
   #[bench]
   fn read_write_hello_world(b: &mut Bencher) {
-    let dir = TempDir::new("random-access-disk").unwrap();
-    let mut file = rad::Sync::new(dir.path().join("3.db"));
+    let dir = tempfile::Builder::new()
+      .prefix("random-access-disk")
+      .tempdir()
+      .unwrap();
+    let mut file = rad::RandomAccessDisk::new(dir.path().join("3.db"));
     b.iter(|| {
       file.write(0, b"hello").unwrap();
       file.write(5, b" world").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub struct RandomAccessDisk {}
 
 impl RandomAccessDisk {
   /// Create a new instance.
-  // #[cfg_attr(test, allow(new_ret_no_self))]
+  #[cfg_attr(feature = "cargo-clippy", allow(new_ret_no_self))]
   pub fn new(filename: path::PathBuf) -> RandomAccess<RandomAccessDiskMethods> {
     RandomAccess::new(RandomAccessDiskMethods {
       filename,

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,10 +1,12 @@
 #[macro_use]
 extern crate quickcheck;
 extern crate random_access_disk as rad;
+extern crate random_access_storage;
 extern crate tempfile;
 
 use self::Op::*;
 use quickcheck::{Arbitrary, Gen};
+use random_access_storage::RandomAccess;
 use std::u8;
 use tempfile::Builder;
 
@@ -37,7 +39,7 @@ quickcheck! {
   fn implementation_matches_model(ops: Vec<Op>) -> bool {
     let dir = Builder::new().prefix("random-access-disk").tempdir().unwrap();
 
-    let mut implementation = rad::RandomAccessDisk::new(dir.path().join("1.db"));
+    let mut implementation = rad::RandomAccessDisk::open(dir.path().join("1.db")).unwrap();
     let mut model = vec![];
 
     for op in ops {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,6 +1,8 @@
 extern crate random_access_disk as rad;
+extern crate random_access_storage;
 extern crate tempfile;
 
+use random_access_storage::RandomAccess;
 use std::env;
 use tempfile::Builder;
 
@@ -12,7 +14,8 @@ fn regress_1() {
     .prefix("random-access-disk")
     .tempdir()
     .unwrap();
-  let mut file = rad::RandomAccessDisk::new(dir.path().join("regression-1.db"));
+  let mut file =
+    rad::RandomAccessDisk::open(dir.path().join("regression-1.db")).unwrap();
   file.write(27, b"").unwrap();
   file.read(13, 5).unwrap();
 }
@@ -25,6 +28,6 @@ fn regress_1() {
 fn regress_2() {
   let mut dir = env::temp_dir();
   dir.push("regression-2.db");
-  let mut file = rad::RandomAccessDisk::new(dir);
+  let mut file = rad::RandomAccessDisk::open(dir).unwrap();
   file.write(27, b"").unwrap();
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,8 @@
 extern crate random_access_disk as rad;
+extern crate random_access_storage;
 extern crate tempfile;
 
+use random_access_storage::RandomAccess;
 use tempfile::Builder;
 
 #[test]
@@ -9,7 +11,7 @@ fn can_call_new() {
     .prefix("random-access-disk")
     .tempdir()
     .unwrap();
-  let _file = rad::RandomAccessDisk::new(dir.path().join("1.db"));
+  let _file = rad::RandomAccessDisk::open(dir.path().join("1.db")).unwrap();
 }
 
 #[test]
@@ -18,9 +20,8 @@ fn can_open_buffer() {
     .prefix("random-access-disk")
     .tempdir()
     .unwrap();
-  let mut file = rad::RandomAccessDisk::new(dir.path().join("2.db"));
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("2.db")).unwrap();
   file.write(0, b"hello").unwrap();
-  assert!(file.opened);
 }
 
 #[test]
@@ -29,7 +30,7 @@ fn can_write() {
     .prefix("random-access-disk")
     .tempdir()
     .unwrap();
-  let mut file = rad::RandomAccessDisk::new(dir.path().join("3.db"));
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("3.db")).unwrap();
   file.write(0, b"hello").unwrap();
   file.write(5, b" world").unwrap();
 }
@@ -40,7 +41,7 @@ fn can_read() {
     .prefix("random-access-disk")
     .tempdir()
     .unwrap();
-  let mut file = rad::RandomAccessDisk::new(dir.path().join("4.db"));
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("4.db")).unwrap();
   file.write(0, b"hello").unwrap();
   file.write(5, b" world").unwrap();
   let text = file.read(0, 11).unwrap();


### PR DESCRIPTION
Upgrade random-access-storage.

Note: the underlying file will be opened/created at `RandomAccessDisk` creation, not at the first method call (`read`, `write` or `del`).

Also note that `read_to_writer()` is not implemented because it's not related to this PR, but it was necessary to include the unimplemented method to make it compile.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
Depends on datrs/random-access-storage#11

## Semver Changes
Minor
