### PR TITLE
len() and is_empty() implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1.3"
-random-access-storage = "1.0.0"
+random-access-storage = "2.0.0"
 mkdirp = "0.1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1.3"
-random-access-storage = "0.6.0"
+random-access-storage = "1.0.0"
 mkdirp = "0.1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,14 @@ impl RandomAccess for RandomAccessDisk {
     file.sync_all()?;
     Ok(())
   }
+
+  fn len(&mut self) -> Result<usize, Self::Error> {
+    Ok(self.length as usize)
+  }
+
+  fn is_empty(&mut self) -> Result<bool, Self::Error> {
+    Ok(self.length == 0)
+  }
 }
 
 impl Drop for RandomAccessDisk {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,14 @@ impl RandomAccess for RandomAccessDisk {
   fn del(&mut self, _offset: usize, _length: usize) -> Result<(), Self::Error> {
     panic!("Not implemented yet");
   }
+
+  fn truncate(&mut self, length: usize) -> Result<(), Self::Error> {
+    let file = self.file.as_ref().expect("self.file was None.");
+    self.length = length as u64;
+    file.set_len(self.length)?;
+    file.sync_all()?;
+    Ok(())
+  }
 }
 
 impl Drop for RandomAccessDisk {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -117,3 +117,41 @@ fn can_truncate_eq() {
   c_file.read_to_string(&mut c_contents).unwrap();
   assert_eq!(c_contents, "hello world");
 }
+
+#[test]
+fn can_len() {
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("8.db")).unwrap();
+  assert_eq!(file.len().unwrap(), 0);
+  file.write(0, b"hello").unwrap();
+  assert_eq!(file.len().unwrap(), 5);
+  file.write(5, b" world").unwrap();
+  assert_eq!(file.len().unwrap(), 11);
+  file.truncate(15).unwrap();
+  assert_eq!(file.len().unwrap(), 15);
+  file.truncate(8).unwrap();
+  assert_eq!(file.len().unwrap(), 8);
+}
+
+#[test]
+fn can_is_empty() {
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("9.db")).unwrap();
+  assert_eq!(file.is_empty().unwrap(), true);
+  file.write(0, b"hello").unwrap();
+  assert_eq!(file.is_empty().unwrap(), false);
+  file.truncate(0).unwrap();
+  assert_eq!(file.is_empty().unwrap(), true);
+  file.truncate(1).unwrap();
+  assert_eq!(file.is_empty().unwrap(), false);
+  file.truncate(0).unwrap();
+  assert_eq!(file.is_empty().unwrap(), true);
+  file.write(0, b"what").unwrap();
+  assert_eq!(file.is_empty().unwrap(), false);
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,8 +3,8 @@ extern crate random_access_storage;
 extern crate tempfile;
 
 use random_access_storage::RandomAccess;
-use tempfile::Builder;
 use std::io::Read;
+use tempfile::Builder;
 
 #[test]
 fn can_call_new() {
@@ -82,7 +82,10 @@ fn can_truncate_gt() {
   file.write(5, b" world").unwrap();
   file.truncate(15).unwrap();
   let text = file.read(0, 15).unwrap();
-  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello world\0\0\0\0");
+  assert_eq!(
+    String::from_utf8(text.to_vec()).unwrap(),
+    "hello world\0\0\0\0"
+  );
   match file.read(0, 16) {
     Ok(_) => panic!("file is too big. read past the end should have failed"),
     _ => {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,6 +4,7 @@ extern crate tempfile;
 
 use random_access_storage::RandomAccess;
 use tempfile::Builder;
+use std::io::Read;
 
 #[test]
 fn can_call_new() {
@@ -46,4 +47,70 @@ fn can_read() {
   file.write(5, b" world").unwrap();
   let text = file.read(0, 11).unwrap();
   assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello world");
+}
+
+#[test]
+fn can_truncate_lt() {
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("5.db")).unwrap();
+  file.write(0, b"hello").unwrap();
+  file.write(5, b" world").unwrap();
+  file.truncate(7).unwrap();
+  let text = file.read(0, 7).unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello w");
+  match file.read(0, 8) {
+    Ok(_) => panic!("file is too big. read past the end should have failed"),
+    _ => {}
+  };
+  let mut c_file = std::fs::File::open(dir.path().join("5.db")).unwrap();
+  let mut c_contents = String::new();
+  c_file.read_to_string(&mut c_contents).unwrap();
+  assert_eq!(c_contents, "hello w");
+}
+
+#[test]
+fn can_truncate_gt() {
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("6.db")).unwrap();
+  file.write(0, b"hello").unwrap();
+  file.write(5, b" world").unwrap();
+  file.truncate(15).unwrap();
+  let text = file.read(0, 15).unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello world\0\0\0\0");
+  match file.read(0, 16) {
+    Ok(_) => panic!("file is too big. read past the end should have failed"),
+    _ => {}
+  };
+  let mut c_file = std::fs::File::open(dir.path().join("6.db")).unwrap();
+  let mut c_contents = String::new();
+  c_file.read_to_string(&mut c_contents).unwrap();
+  assert_eq!(c_contents, "hello world\0\0\0\0");
+}
+
+#[test]
+fn can_truncate_eq() {
+  let dir = Builder::new()
+    .prefix("random-access-disk")
+    .tempdir()
+    .unwrap();
+  let mut file = rad::RandomAccessDisk::open(dir.path().join("7.db")).unwrap();
+  file.write(0, b"hello").unwrap();
+  file.write(5, b" world").unwrap();
+  file.truncate(11).unwrap();
+  let text = file.read(0, 11).unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello world");
+  match file.read(0, 12) {
+    Ok(_) => panic!("file is too big. read past the end should have failed"),
+    _ => {}
+  };
+  let mut c_file = std::fs::File::open(dir.path().join("7.db")).unwrap();
+  let mut c_contents = String::new();
+  c_file.read_to_string(&mut c_contents).unwrap();
+  assert_eq!(c_contents, "hello world");
 }


### PR DESCRIPTION
This patch implements `len()` and `is_empty()` methods introduced in random-access-storage 2.0.0.

https://github.com/datrs/random-access-storage/pull/16