### PR TITLE
Make `open`/`create`/`builder` accept `&PathBuf` and others

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,13 +188,13 @@ impl RandomAccessDisk {
   /// Create a new (auto-sync) instance to storage at `filename`.
   #[allow(clippy::new_ret_no_self)]
   pub async fn open(
-    filename: path::PathBuf,
+    filename: impl AsRef<path::Path>,
   ) -> Result<RandomAccessDisk, RandomAccessError> {
     Self::builder(filename).build().await
   }
 
   /// Initialize a builder with storage at `filename`.
-  pub fn builder(filename: path::PathBuf) -> Builder {
+  pub fn builder(filename: impl AsRef<path::Path>) -> Builder {
     Builder::new(filename)
   }
 }
@@ -345,9 +345,9 @@ pub struct Builder {
 
 impl Builder {
   /// Create new builder at `path` (with auto-sync true by default).
-  pub fn new(filename: path::PathBuf) -> Self {
+  pub fn new(filename: impl AsRef<path::Path>) -> Self {
     Self {
-      filename,
+      filename: filename.as_ref().into(),
       auto_sync: true,
     }
   }


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?
🙋 feature

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
<!-- Is this related to any GitHub issue(s)? -->
I'm building lsp-proxy and happen to found this crate (thankyou), and this has been bugging me
```rs
async fn did_open(&self, params: DidOpenTextDocumentParams) {
  let path = Path::new(params.text_document.uri.path());
  let file = RandomAccess::open(path.clone().into());
  // using `path` for something else
}
```
This change avoid the need for `clone()` by using `&path`.
It also mirror to `std::fs::File::open<P: AsRef<Path>>(path: P)`.

## Semver Changes
<!-- Which semantic version change would you recommend? -->
3.1.0