### PR TITLE
Add method to acquire BufReader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 tokio = { version = "1.27.0", features = ["macros", "rt", "rt-multi-thread"] }
 criterion = { version = "0.4", features = ["async_std", "async_tokio"] }
 tokio-test = "0.4"
+tokio-stream = { version="0.1.14", features = ["io-util"] }
 
 [features]
 default = ["sparse", "async-std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ compile_error!("features `random-access-disk/async-std` and `random-access-disk/
 use async_std::{
   fs::{self, OpenOptions},
   io::prelude::{SeekExt, WriteExt},
-  io::{ReadExt, SeekFrom},
+  io::{BufReader, ReadExt, SeekFrom},
 };
 use random_access_storage::{RandomAccess, RandomAccessError};
 use std::ops::Drop;
@@ -120,7 +120,7 @@ use std::io::SeekFrom;
 #[cfg(feature = "tokio")]
 use tokio::{
   fs::{self, OpenOptions},
-  io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
+  io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader},
 };
 
 #[cfg(all(
@@ -196,6 +196,11 @@ impl RandomAccessDisk {
   /// Initialize a builder with storage at `filename`.
   pub fn builder(filename: impl AsRef<path::Path>) -> Builder {
     Builder::new(filename)
+  }
+
+  /// Acquire buffered reader.
+  pub fn reader(&self) -> BufReader<&fs::File> {
+    BufReader::new(&self.file)
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,29 @@ impl RandomAccessDisk {
   }
 
   /// Acquire buffered reader.
+  /// # Examples
+  /// Read each lines to delete on specific line/column
+  ///
+  /// ```no_run
+  /// # use random_access_disk::RandomAccessDisk;
+  /// # use random_access_storage::RandomAccess;
+  /// # use async_std::prelude::*;
+  /// # #[async_std::main]
+  /// # async fn main() {
+  /// let line = 10;
+  /// let column = 10;
+  /// let length = 5;
+  ///
+  /// let mut file = RandomAccessDisk::open("text.db").await.unwrap();
+  ///
+  /// let offset = column + file.reader()
+  ///     .lines().take(line - 1)
+  ///     .fold(column, |acc, line| acc + line.unwrap().len() as u64)
+  ///     .await;
+  ///
+  /// let _ = file.del(offset, length).await;
+  /// # }
+  /// ```
   pub fn reader(&self) -> BufReader<&fs::File> {
     BufReader::new(&self.file)
   }


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?
🙋 feature

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
<!-- Is this related to any GitHub issue(s)? -->
I have a case where I store RandomAccessDisk in struct like this
```rs
struct LSPBackend {
  files: HashMap<Url, RandomAccessDisk>, // I store the file instead of path to make it efficient
  // ...other stuff
}
```
It's quite common to do buffered read so I expose `reader()` method.
Accessing the underlying `fs::File` is possible by calling `reader().get_ref()` or `reader().get_mut()`.

The `reader()` method open up the possibility for this pattern
```rs
let line = 10;
let column = 10;
let length = 5;

let mut file = RandomAccessDisk::open("text.db").await.unwrap();

let offset = column + (
    file.reader()
        .lines()
        .take(line - 1)
        .fold(column, |acc, line| acc + line.unwrap().len() as u64)
        .await
);

let _ = file.del(offset, length).await;
```

## Semver Changes
<!-- Which semantic version change would you recommend? -->
3.1.0