### PR TITLE
Add read_to method for zero-allocation reads 🙋 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "random-access-disk"
 readme = "README.md"
 repository = "https://github.com/datrs/random-access-disk"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
🙋 feature

  ## Checklist
  - [x] tests pass
  - [x] tests and/or benchmarks are included
  - [x] documentation is changed or added

  ## Context
  Adds `read_to` method that reads into a provided buffer, avoiding allocation on each read. The existing `read` method now uses `read_to` internally.

  ## Semver Changes
  Minor (new public method)